### PR TITLE
enhancement: Simplifies the transformed output

### DIFF
--- a/.changeset/big-bottles-look.md
+++ b/.changeset/big-bottles-look.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/pp': patch
+---
+
+simplifies the transformed output

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ export function preprocessMeltUI(options?: PreprocessOptions): PreprocessorGroup
 					identifiersToInsert += `$: ${identifier} = ${builder.expression.contents};\n`;
 				}
 
-				const attributes = `{...{...${identifier}, action: undefined}} use:${identifier}.action`;
+				const attributes = `{...${identifier}} use:${identifier}.action`;
 
 				// replace the `melt={...}` with the attributes
 				config.markup.overwrite(builder.startPos, builder.endPos, attributes, {

--- a/tests/await_block/index.svelte.ts
+++ b/tests/await_block/index.svelte.ts
@@ -34,9 +34,9 @@ export const basicAwaitExpected = `
 {#await promise}
 	<div />
 {:then item}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
-	<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 {:catch error}{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error, arg2: '' })}
-	<div {...{...__MELTUI_BUILDER_1__, action: undefined}} use:__MELTUI_BUILDER_1__.action />
+	<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 {/await}
 `;
 
@@ -72,9 +72,9 @@ export const basicShorthandAwaitExpected = `
 </script>
 
 {#await promise then item}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
-	<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 {:catch error}{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error, arg2: '' })}
-	<div {...{...__MELTUI_BUILDER_1__, action: undefined}} use:__MELTUI_BUILDER_1__.action />
+	<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 {/await}
 `;
 
@@ -117,9 +117,9 @@ $: __MELTUI_BUILDER_1__ = $builder({ arg1: 1, arg2: '' });
 {#await promise}
 	<div />
 {:then item}
-	<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 {:catch error}
-	<div {...{...__MELTUI_BUILDER_1__, action: undefined}} use:__MELTUI_BUILDER_1__.action />
+	<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 {/await}
 `;
 
@@ -155,9 +155,9 @@ export const basicIdentifierAwaitExpected = `
 {#await promise}
 	<div />
 {:then item}
-	<div {...{...$builder, action: undefined}} use:$builder.action />
+	<div {...$builder} use:$builder.action />
 {:catch error}
-	<div {...{...$builder, action: undefined}} use:$builder.action />
+	<div {...$builder} use:$builder.action />
 {/await}
 `;
 
@@ -197,9 +197,9 @@ export const duplicateIdentifierAwaitExpected = `
 {#await promise}
 	<div />
 {:then item}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item })}
-	<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 {:catch error}{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error, arg2: error })}
-	<div {...{...__MELTUI_BUILDER_1__, action: undefined}} use:__MELTUI_BUILDER_1__.action />
+	<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 {/await}
 `;
 
@@ -239,9 +239,9 @@ export const destructuredAwaitExpected = `
 {#await promise}
 	<div />
 {:then {item1, item2}}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
-	<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 {:catch {error1, error2}}{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error1, arg2: error2 })}
-	<div {...{...__MELTUI_BUILDER_1__, action: undefined}} use:__MELTUI_BUILDER_1__.action />
+	<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 {/await}
 `;
 
@@ -287,18 +287,18 @@ export const scopedAwaitExpected = `
 </script>
 
 {#await promise then item}{@const __MELTUI_BUILDER_2__ = $builder({ arg1: item, arg2: '' })}
-	<div {...{...__MELTUI_BUILDER_2__, action: undefined}} use:__MELTUI_BUILDER_2__.action />
+	<div {...__MELTUI_BUILDER_2__} use:__MELTUI_BUILDER_2__.action />
 	{#await promise then item}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
-		<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{:catch error}{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error, arg2: '' })}
-		<div {...{...__MELTUI_BUILDER_1__, action: undefined}} use:__MELTUI_BUILDER_1__.action />
+		<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 	{/await}
 {:catch error}{@const __MELTUI_BUILDER_5__ = $builder({ arg1: error, arg2: '' })}
-	<div {...{...__MELTUI_BUILDER_5__, action: undefined}} use:__MELTUI_BUILDER_5__.action />
+	<div {...__MELTUI_BUILDER_5__} use:__MELTUI_BUILDER_5__.action />
 	{#await promise2 then item}{@const __MELTUI_BUILDER_3__ = $builder({ arg1: item, arg2: '' })}
-		<div {...{...__MELTUI_BUILDER_3__, action: undefined}} use:__MELTUI_BUILDER_3__.action />
+		<div {...__MELTUI_BUILDER_3__} use:__MELTUI_BUILDER_3__.action />
 	{:catch error}{@const __MELTUI_BUILDER_4__ = $builder({ arg1: error, arg2: '' })}
-		<div {...{...__MELTUI_BUILDER_4__, action: undefined}} use:__MELTUI_BUILDER_4__.action />
+		<div {...__MELTUI_BUILDER_4__} use:__MELTUI_BUILDER_4__.action />
 	{/await}
 {/await}
 `;
@@ -344,15 +344,15 @@ export const nestedAwaitUpperExpected = `
 
 {#await promise then item}{@const __MELTUI_BUILDER_1__ = $builder({ arg1: item, arg2: '' })}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
 	{#await promise then item2}
-		<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{:catch error}
-		<div {...{...__MELTUI_BUILDER_1__, action: undefined}} use:__MELTUI_BUILDER_1__.action />
+		<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 	{/await}
 {:catch error1}{@const __MELTUI_BUILDER_3__ = $builder({ arg1: error1, arg2: '' })}{@const __MELTUI_BUILDER_2__ = $builder({ arg1: error1, arg2: '' })}
 	{#await promise then item}
-		<div {...{...__MELTUI_BUILDER_2__, action: undefined}} use:__MELTUI_BUILDER_2__.action />
+		<div {...__MELTUI_BUILDER_2__} use:__MELTUI_BUILDER_2__.action />
 	{:catch error2}
-		<div {...{...__MELTUI_BUILDER_3__, action: undefined}} use:__MELTUI_BUILDER_3__.action />
+		<div {...__MELTUI_BUILDER_3__} use:__MELTUI_BUILDER_3__.action />
 	{/await}
 {/await}
 `;
@@ -390,7 +390,7 @@ export const nestedAwaitLowerExpected = `
 
 {#await promise then item}
 	{#await promise then item2}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item2, arg2: '' })}
-		<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{/await}
 {/await}
 `;
@@ -428,7 +428,7 @@ export const nestedAwaitBothExpected = `
 
 {#await promise then item}
 	{#await promise then item2}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
-		<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{/await}
 {/await}
 `;

--- a/tests/component_block/index.svelte.ts
+++ b/tests/component_block/index.svelte.ts
@@ -28,7 +28,7 @@ export const basicComponentExpected = `
 </script>
 
 <Component let:data={item}>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
-	<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 </Component>
 `;
 
@@ -62,7 +62,7 @@ export const basicShorthandExpected = `
 </script>
 
 <Component let:item>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
-	<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 </Component>
 `;
 
@@ -98,7 +98,7 @@ $: __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' });
 </script>
 
 <Component let:item>
-	<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 </Component>
 `;
 
@@ -110,7 +110,7 @@ export const basicIdentifier = `
 
 export const basicIdentifierExpected = `
 <Component let:builder>
-	<div {...{...builder, action: undefined}} use:builder.action />
+	<div {...builder} use:builder.action />
 </Component>
 `;
 
@@ -144,7 +144,7 @@ export const duplicateIdentifierExpected = `
 </script>
 
 <Component let:item>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item })}
-	<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 </Component>
 `;
 
@@ -178,7 +178,7 @@ export const destructuredExpected = `
 </script>
 
 <Component let:item={{item1, item2}}>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
-	<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 </Component>
 `;
 
@@ -215,7 +215,7 @@ export const scopedExpected = `
 
 <Component let:item>
 	<Component let:item>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
-		<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	</Component>
 </Component>
 `;
@@ -253,7 +253,7 @@ export const nestedUpperExpected = `
 
 <Component let:item1>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: '' })}
 	<Component let:item2>
-		<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	</Component>
 </Component>
 `;
@@ -291,7 +291,7 @@ export const nestedLowerExpected = `
 
 <Component let:item1>
 	<Component let:item2>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item2, arg2: '' })}
-		<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	</Component>
 </Component>
 `;
@@ -329,7 +329,7 @@ export const nestedBothExpected = `
 
 <Component let:item1>
 	<Component let:item2>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
-		<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	</Component>
 </Component>
 `;
@@ -367,7 +367,7 @@ export const slotTemplateExpected = `
 
 <Component let:item1>
 	<svelte:fragment slot="name" let:item2>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
-		<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	</svelte:fragment>
 </Component>
 `;

--- a/tests/each_block/index.svelte.ts
+++ b/tests/each_block/index.svelte.ts
@@ -28,7 +28,7 @@ export const basicEachExpected = `
 </script>
 
 {#each [1, 2, 3] as item}
-	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 {/each}
 `;
 
@@ -64,7 +64,7 @@ $: __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' });
 </script>
 
 {#each [1, 2, 3] as item}
-	<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 {/each}
 `;
 
@@ -94,7 +94,7 @@ export const basicIdentifierEachExpected = `
 </script>
 
 {#each [1, 2, 3] as item}
-	<div {...{...$builder, action: undefined}} use:$builder.action />
+	<div {...$builder} use:$builder.action />
 {/each}
 `;
 
@@ -128,7 +128,7 @@ export const duplicateEachExpected = `
 </script>
 
 {#each [1, 2, 3] as item}
-	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item })}<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 {/each}
 `;
 
@@ -162,7 +162,7 @@ export const destructuredEachExpected = `
 </script>
 
 {#each [{item1: 1, item2: 1}, {item1: 2, item2: 2}, {item1: 3, item2: 3}] as {item1, item2}}
-	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 {/each}
 `;
 
@@ -199,7 +199,7 @@ export const scopedEachExpected = `
 
 {#each [1, 2, 3] as item}
 	{#each [4, 5, 6] as item}
-		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{/each}
 {/each}
 `;
@@ -237,7 +237,7 @@ export const nestedEachUpperExpected = `
 
 {#each [1, 2, 3] as item}
 	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}{#each [4, 5, 6] as item2}
-		<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{/each}
 {/each}
 `;
@@ -275,7 +275,7 @@ export const nestedEachLowerExpected = `
 
 {#each [1, 2, 3] as item}
 	{#each [4, 5, 6] as item2}
-		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item2, arg2: '' })}<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item2, arg2: '' })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{/each}
 {/each}
 `;
@@ -313,7 +313,7 @@ export const nestedEachBothExpected = `
 
 {#each [1, 2, 3] as item}
 	{#each [4, 5, 6] as item2}
-		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item2 })}<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item2 })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{/each}
 {/each}
 `;

--- a/tests/expression_builder/index.svelte.ts
+++ b/tests/expression_builder/index.svelte.ts
@@ -27,7 +27,7 @@ export const callExpressionExpected = `
 $: __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' });
 </script>
 
-<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 `;
 
 export const objExpression = `
@@ -59,7 +59,7 @@ export const objExpressionExpected = `
 $: __MELTUI_BUILDER_0__ = { ...$builder({ arg1: 1, arg2: '' }) };
 </script>
 
-<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
+<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 `;
 
 export const multiExpressions = `
@@ -95,7 +95,7 @@ $: __MELTUI_BUILDER_1__ = $builder({ arg1: 1, arg2: '' });
 $: __MELTUI_BUILDER_2__ = $builder({ arg1: 1, arg2: '' });
 </script>
 
-<div {...{...__MELTUI_BUILDER_0__, action: undefined}} use:__MELTUI_BUILDER_0__.action />
-<div {...{...__MELTUI_BUILDER_1__, action: undefined}} use:__MELTUI_BUILDER_1__.action />
-<div {...{...__MELTUI_BUILDER_2__, action: undefined}} use:__MELTUI_BUILDER_2__.action />
+<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
+<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
+<div {...__MELTUI_BUILDER_2__} use:__MELTUI_BUILDER_2__.action />
 `;

--- a/tests/simple_builder/index.svelte.ts
+++ b/tests/simple_builder/index.svelte.ts
@@ -21,7 +21,7 @@ export const simpleExpected = `
 	});
 </script>
 
-<div {...{...$builder, action: undefined}} use:$builder.action />
+<div {...$builder} use:$builder.action />
 `;
 
 export const aliased = `
@@ -68,8 +68,8 @@ export const aliasedExpected = `
 	const expressionAlias = $expressionBuilder({ arg1: 1, arg2: '' });
 </script>
 
-<div {...{...alias, action: undefined}} use:alias.action />
-<div {...{...expressionAlias, action: undefined}} use:expressionAlias.action />
+<div {...alias} use:alias.action />
+<div {...expressionAlias} use:expressionAlias.action />
 `;
 
 export const ignore = `
@@ -104,12 +104,12 @@ export const ignoreExpected = `
 	});
 </script>
 
-<div {...{...$builder, action: undefined}} use:$builder.action />
+<div {...$builder} use:$builder.action />
 
 <Comp melt={$builder} />
 <Comp melt={builder} />
 
 <Comp melt={$builder}>
-	<div {...{...$builder, action: undefined}} use:$builder.action />
+	<div {...$builder} use:$builder.action />
 </Comp>
 `;


### PR DESCRIPTION
The previous version of the transformed syntax was added as a temporary workaround. As it's no longer needed, we can now revert back to the original output syntax.