### PR TITLE
fix: Handle the shorthand notation for the `melt` attribute

### DIFF
--- a/.changeset/spicy-kangaroos-call.md
+++ b/.changeset/spicy-kangaroos-call.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/pp': patch
+---
+
+fix: Handle the shorthand notation for the `melt` attribute (ex: `<div {melt} />`)

--- a/src/traverse/index.ts
+++ b/src/traverse/index.ts
@@ -54,7 +54,8 @@ export function traverse({ baseNode, config }: TraverseArgs) {
 				node.type === 'Attribute' &&
 				isAliasedAction(node.name, config.alias) &&
 				node.value[0] &&
-				node.value[0].type === 'MustacheTag' &&
+				(node.value[0].type === 'MustacheTag' ||
+					node.value[0].type === 'AttributeShorthand') && // handles shorthand {melt}
 				node.value[0].expression !== null // assigned to something
 			) {
 				actions.push(node);

--- a/tests/simple_builder/index.svelte.ts
+++ b/tests/simple_builder/index.svelte.ts
@@ -72,7 +72,7 @@ export const aliasedExpected = `
 <div {...expressionAlias} use:expressionAlias.action />
 `;
 
-export const ignore = `
+export const ignoreComps = `
 <script>
 	import { writable } from 'svelte/store';
 	import Comp from "./Comp.svelte";
@@ -93,7 +93,7 @@ export const ignore = `
 </Comp>
 `;
 
-export const ignoreExpected = `
+export const ignoreCompsExpected = `
 <script>
 	import { writable } from 'svelte/store';
 	import Comp from "./Comp.svelte";
@@ -111,5 +111,49 @@ export const ignoreExpected = `
 
 <Comp melt={$builder}>
 	<div {...$builder} use:$builder.action />
+</Comp>
+`;
+
+export const meltAlias = `
+<script>
+	import { writable } from 'svelte/store';
+	import Comp from "./Comp.svelte";
+
+	const builder = writable({
+		role: 'Mock',
+		action: () => {},
+	});
+
+	$: melt = $builder;
+</script>
+
+<div {melt} />
+
+<Comp {melt} />
+
+<Comp {melt}>
+	<div {melt} />
+</Comp>
+`;
+
+export const meltAliasExpected = `
+<script>
+	import { writable } from 'svelte/store';
+	import Comp from "./Comp.svelte";
+
+	const builder = writable({
+		role: 'Mock',
+		action: () => {},
+	});
+
+	$: melt = $builder;
+</script>
+
+<div {...melt} use:melt.action />
+
+<Comp {melt} />
+
+<Comp {melt}>
+	<div {...melt} use:melt.action />
 </Comp>
 `;

--- a/tests/simple_builder/index.test.ts
+++ b/tests/simple_builder/index.test.ts
@@ -5,8 +5,10 @@ import {
 	simpleExpected,
 	aliased,
 	aliasedExpected,
-	ignore,
-	ignoreExpected,
+	meltAlias,
+	meltAliasExpected,
+	ignoreComps,
+	ignoreCompsExpected,
 } from './index.svelte';
 
 describe('Simple Builder - Identifiers', () => {
@@ -29,11 +31,19 @@ describe('Simple Builder - Identifiers', () => {
 		expect(processed?.code).toBe(aliasedExpected);
 	});
 
-	it('ignore component props', async () => {
+	it('builder aliased as melt with AttributeShorthand', async () => {
 		const processed = await markup({
-			content: ignore,
+			content: meltAlias,
 		});
 
-		expect(processed?.code).toBe(ignoreExpected);
+		expect(processed?.code).toBe(meltAliasExpected);
+	});
+
+	it('ignore component props', async () => {
+		const processed = await markup({
+			content: ignoreComps,
+		});
+
+		expect(processed?.code).toBe(ignoreCompsExpected);
 	});
 });


### PR DESCRIPTION
This PR addresses the case where the `melt` attribute could be added to elements with the shorthand attribute notation like so:
```html
<script>
	const { builder } = createBuilder();
	
	$: melt = $builder;
</script>

<div {melt} />
```

