### PR TITLE
refactor: Replaces all instances of `use:melt` instead of the `melt` attribute

### DIFF
--- a/.changeset/lazy-windows-jump.md
+++ b/.changeset/lazy-windows-jump.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/pp': minor
+---
+
+refactor: Replaces all instances of `use:melt` instead of `melt`

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,8 +1,8 @@
 {
-  "mode": "pre",
-  "tag": "next",
-  "initialVersions": {
-    "@melt-ui/pp": "0.0.7"
-  },
-  "changesets": []
+	"mode": "pre",
+	"tag": "next",
+	"initialVersions": {
+		"@melt-ui/pp": "0.0.7"
+	},
+	"changesets": []
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,8 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "@melt-ui/pp": "0.0.7"
+  },
+  "changesets": []
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export type PreprocessOptions = {
 /**
  * A preprocessor for Melt UI.
  *
- * Intelligently replaces all instances of `melt={$builder}` with the correct spread syntax,
+ * Intelligently replaces all instances of `use:melt={$builder}` with the correct spread syntax,
  * providing a sleeker developer experience.
  *
  * Simply add it to the end of your array of preprocessors.
@@ -86,7 +86,7 @@ export function preprocessMeltUI(options?: PreprocessOptions): PreprocessorGroup
 
 				const attributes = `{...${identifier}} use:${identifier}.action`;
 
-				// replace the `melt={...}` with the attributes
+				// replace the `use:melt={...}` with the attributes
 				config.markup.overwrite(builder.startPos, builder.endPos, attributes, {
 					storeName: true,
 				});
@@ -121,11 +121,11 @@ type HandleTopLevelActionArgs = {
 function handleTopLevelAction(args: HandleTopLevelActionArgs) {
 	const { actionNode, config } = args;
 	let identifierName: string | undefined;
-	const expression = actionNode.value[0].expression as Node;
+	const expression = actionNode.expression as Node;
 
 	if (expression.type === 'Identifier') {
 		// only an identifier was passed
-		// i.e. melt={$builder}
+		// i.e. use:melt={$builder}
 		identifierName = expression.name;
 		config.builders.push({
 			identifierName,
@@ -134,7 +134,7 @@ function handleTopLevelAction(args: HandleTopLevelActionArgs) {
 		});
 	} else {
 		// any other expression type...
-		// i.e. melt={$builder({ arg1: '', arg2: '' })}
+		// i.e. use:melt={$builder({ arg1: '', arg2: '' })}
 		config.builders.push({
 			expression: {
 				startPos: expression.start,

--- a/src/traverse/Block.ts
+++ b/src/traverse/Block.ts
@@ -7,7 +7,7 @@ import {
 import { traverse } from './index.js';
 
 import type { TemplateNode } from 'svelte/types/compiler/interfaces';
-import type { Config } from '../types.js';
+import type { Config, Node } from '../types.js';
 
 type BlockArgs = {
 	blockNode: TemplateNode;
@@ -33,7 +33,7 @@ export function traverseBlock(args: BlockArgs) {
 		enter(node, parent) {
 			if (
 				parent?.type !== 'InlineComponent' && // we don't want to process component props
-				node.type === 'Attribute' &&
+				node.type === 'Action' &&
 				isAliasedAction(node.name, config.alias) &&
 				node.expression !== null // assigned to something
 			) {
@@ -88,12 +88,12 @@ function handleActionNode({
 	knownIdentifiers,
 	blockNode,
 }: HandleActionNodeArgs) {
-	const expression = actionNode.value[0].expression as TemplateNode;
+	const expression = actionNode.expression as Node;
 	const expressionIdentifiers = new Set<string>();
 	let inserted = false;
 
 	// any other expression type...
-	// i.e. melt={$builder({ arg1: '', arg2: '' })}
+	// i.e. use:melt={$builder({ arg1: '', arg2: '' })}
 	if (expression.type !== 'Identifier') {
 		const expressionContent = config.content.substring(expression.start, expression.end);
 		extractIdentifiers(expression).forEach((identifier) =>

--- a/src/traverse/index.ts
+++ b/src/traverse/index.ts
@@ -50,13 +50,10 @@ export function traverse({ baseNode, config }: TraverseArgs) {
 
 			// top level Actions
 			if (
-				parent?.type !== 'InlineComponent' && // we don't want to process component props
-				node.type === 'Attribute' &&
+				parent?.type !== 'InlineComponent' && // we don't want to process component props (even though Actions can only be applied to DOM elements)
+				node.type === 'Action' &&
 				isAliasedAction(node.name, config.alias) &&
-				node.value[0] &&
-				(node.value[0].type === 'MustacheTag' ||
-					node.value[0].type === 'AttributeShorthand') && // handles shorthand {melt}
-				node.value[0].expression !== null // assigned to something
+				node.expression !== null // assigned to something
 			) {
 				actions.push(node);
 				// we don't have to walk the Action's children

--- a/tests/await_block/index.svelte.ts
+++ b/tests/await_block/index.svelte.ts
@@ -1,6 +1,7 @@
 export const basicAwait = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -13,15 +14,16 @@ export const basicAwait = `
 {#await promise}
 	<div />
 {:then item}
-	<div melt={$builder({ arg1: item, arg2: '' })} />
+	<div use:melt={$builder({ arg1: item, arg2: '' })} />
 {:catch error}
-	<div melt={$builder({ arg1: error, arg2: '' })} />
+	<div use:melt={$builder({ arg1: error, arg2: '' })} />
 {/await}
 `;
 
 export const basicAwaitExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -43,6 +45,7 @@ export const basicAwaitExpected = `
 export const basicShorthandAwait = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -53,15 +56,16 @@ export const basicShorthandAwait = `
 </script>
 
 {#await promise then item}
-	<div melt={$builder({ arg1: item, arg2: '' })} />
+	<div use:melt={$builder({ arg1: item, arg2: '' })} />
 {:catch error}
-	<div melt={$builder({ arg1: error, arg2: '' })} />
+	<div use:melt={$builder({ arg1: error, arg2: '' })} />
 {/await}
 `;
 
 export const basicShorthandAwaitExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -81,6 +85,7 @@ export const basicShorthandAwaitExpected = `
 export const controlAwait = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -93,15 +98,16 @@ export const controlAwait = `
 {#await promise}
 	<div />
 {:then item}
-	<div melt={$builder({ arg1: 1, arg2: '' })} />
+	<div use:melt={$builder({ arg1: 1, arg2: '' })} />
 {:catch error}
-	<div melt={$builder({ arg1: 1, arg2: '' })} />
+	<div use:melt={$builder({ arg1: 1, arg2: '' })} />
 {/await}
 `;
 
 export const controlAwaitExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -126,6 +132,7 @@ $: __MELTUI_BUILDER_1__ = $builder({ arg1: 1, arg2: '' });
 export const basicIdentifierAwait = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable({
 		role: 'Mock',
@@ -136,15 +143,16 @@ export const basicIdentifierAwait = `
 {#await promise}
 	<div />
 {:then item}
-	<div melt={$builder} />
+	<div use:melt={$builder} />
 {:catch error}
-	<div melt={$builder} />
+	<div use:melt={$builder} />
 {/await}
 `;
 
 export const basicIdentifierAwaitExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable({
 		role: 'Mock',
@@ -164,6 +172,7 @@ export const basicIdentifierAwaitExpected = `
 export const duplicateIdentifierAwait = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -176,15 +185,16 @@ export const duplicateIdentifierAwait = `
 {#await promise}
 	<div />
 {:then item}
-	<div melt={$builder({ arg1: item, arg2: item })} />
+	<div use:melt={$builder({ arg1: item, arg2: item })} />
 {:catch error}
-	<div melt={$builder({ arg1: error, arg2: error })} />
+	<div use:melt={$builder({ arg1: error, arg2: error })} />
 {/await}
 `;
 
 export const duplicateIdentifierAwaitExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -206,6 +216,7 @@ export const duplicateIdentifierAwaitExpected = `
 export const destructuredAwait = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -218,15 +229,16 @@ export const destructuredAwait = `
 {#await promise}
 	<div />
 {:then {item1, item2}}
-	<div melt={$builder({ arg1: item1, arg2: item2 })} />
+	<div use:melt={$builder({ arg1: item1, arg2: item2 })} />
 {:catch {error1, error2}}
-	<div melt={$builder({ arg1: error1, arg2: error2 })} />
+	<div use:melt={$builder({ arg1: error1, arg2: error2 })} />
 {/await}
 `;
 
 export const destructuredAwaitExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -248,6 +260,7 @@ export const destructuredAwaitExpected = `
 export const scopedAwait = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -258,18 +271,18 @@ export const scopedAwait = `
 </script>
 
 {#await promise then item}
-	<div melt={$builder({ arg1: item, arg2: '' })} />
+	<div use:melt={$builder({ arg1: item, arg2: '' })} />
 	{#await promise then item}
-		<div melt={$builder({ arg1: item, arg2: '' })} />
+		<div use:melt={$builder({ arg1: item, arg2: '' })} />
 	{:catch error}
-		<div melt={$builder({ arg1: error, arg2: '' })} />
+		<div use:melt={$builder({ arg1: error, arg2: '' })} />
 	{/await}
 {:catch error}
-	<div melt={$builder({ arg1: error, arg2: '' })} />
+	<div use:melt={$builder({ arg1: error, arg2: '' })} />
 	{#await promise2 then item}
-		<div melt={$builder({ arg1: item, arg2: '' })} />
+		<div use:melt={$builder({ arg1: item, arg2: '' })} />
 	{:catch error}
-		<div melt={$builder({ arg1: error, arg2: '' })} />
+		<div use:melt={$builder({ arg1: error, arg2: '' })} />
 	{/await}
 {/await}
 `;
@@ -277,6 +290,7 @@ export const scopedAwait = `
 export const scopedAwaitExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -306,6 +320,7 @@ export const scopedAwaitExpected = `
 export const nestedAwaitUpper = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -317,15 +332,15 @@ export const nestedAwaitUpper = `
 
 {#await promise then item}
 	{#await promise then item2}
-		<div melt={$builder({ arg1: item, arg2: '' })} />
+		<div use:melt={$builder({ arg1: item, arg2: '' })} />
 	{:catch error}
-		<div melt={$builder({ arg1: item, arg2: '' })} />
+		<div use:melt={$builder({ arg1: item, arg2: '' })} />
 	{/await}
 {:catch error1}
 	{#await promise then item}
-		<div melt={$builder({ arg1: error1, arg2: '' })} />
+		<div use:melt={$builder({ arg1: error1, arg2: '' })} />
 	{:catch error2}
-		<div melt={$builder({ arg1: error1, arg2: '' })} />
+		<div use:melt={$builder({ arg1: error1, arg2: '' })} />
 	{/await}
 {/await}
 `;
@@ -333,6 +348,7 @@ export const nestedAwaitUpper = `
 export const nestedAwaitUpperExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -360,6 +376,7 @@ export const nestedAwaitUpperExpected = `
 export const nestedAwaitLower = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -371,7 +388,7 @@ export const nestedAwaitLower = `
 
 {#await promise then item}
 	{#await promise then item2}
-		<div melt={$builder({ arg1: item2, arg2: '' })} />
+		<div use:melt={$builder({ arg1: item2, arg2: '' })} />
 	{/await}
 {/await}
 `;
@@ -379,6 +396,7 @@ export const nestedAwaitLower = `
 export const nestedAwaitLowerExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -398,6 +416,7 @@ export const nestedAwaitLowerExpected = `
 export const nestedAwaitBoth = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -409,7 +428,7 @@ export const nestedAwaitBoth = `
 
 {#await promise then item}
 	{#await promise then item2}
-		<div melt={$builder({ arg1: item1, arg2: item2 })} />
+		<div use:melt={$builder({ arg1: item1, arg2: item2 })} />
 	{/await}
 {/await}
 `;
@@ -417,6 +436,7 @@ export const nestedAwaitBoth = `
 export const nestedAwaitBothExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {

--- a/tests/component_block/index.svelte.ts
+++ b/tests/component_block/index.svelte.ts
@@ -1,6 +1,7 @@
 export const basicComponent = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -11,13 +12,14 @@ export const basicComponent = `
 </script>
 
 <Component let:data={item}>
-	<div melt={$builder({ arg1: item, arg2: '' })} />
+	<div use:melt={$builder({ arg1: item, arg2: '' })} />
 </Component>
 `;
 
 export const basicComponentExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -35,6 +37,7 @@ export const basicComponentExpected = `
 export const basicShorthand = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -45,13 +48,14 @@ export const basicShorthand = `
 </script>
 
 <Component let:item>
-	<div melt={$builder({ arg1: item, arg2: '' })} />
+	<div use:melt={$builder({ arg1: item, arg2: '' })} />
 </Component>
 `;
 
 export const basicShorthandExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -69,6 +73,7 @@ export const basicShorthandExpected = `
 export const control = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -79,13 +84,14 @@ export const control = `
 </script>
 
 <Component let:item>
-	<div melt={$builder({ arg1: 1, arg2: '' })} />
+	<div use:melt={$builder({ arg1: 1, arg2: '' })} />
 </Component>
 `;
 
 export const controlExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -104,7 +110,7 @@ $: __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' });
 
 export const basicIdentifier = `
 <Component let:builder>
-	<div melt={builder} />
+	<div use:melt={builder} />
 </Component>
 `;
 
@@ -117,6 +123,7 @@ export const basicIdentifierExpected = `
 export const duplicateIdentifier = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -127,13 +134,14 @@ export const duplicateIdentifier = `
 </script>
 
 <Component let:item>
-	<div melt={$builder({ arg1: item, arg2: item })} />
+	<div use:melt={$builder({ arg1: item, arg2: item })} />
 </Component>
 `;
 
 export const duplicateIdentifierExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -151,6 +159,7 @@ export const duplicateIdentifierExpected = `
 export const destructured = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -161,13 +170,14 @@ export const destructured = `
 </script>
 
 <Component let:item={{item1, item2}}>
-	<div melt={$builder({ arg1: item1, arg2: item2 })} />
+	<div use:melt={$builder({ arg1: item1, arg2: item2 })} />
 </Component>
 `;
 
 export const destructuredExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -185,6 +195,7 @@ export const destructuredExpected = `
 export const scoped = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -196,7 +207,7 @@ export const scoped = `
 
 <Component let:item>
 	<Component let:item>
-		<div melt={$builder({ arg1: item, arg2: '' })} />
+		<div use:melt={$builder({ arg1: item, arg2: '' })} />
 	</Component>
 </Component>
 `;
@@ -204,6 +215,7 @@ export const scoped = `
 export const scopedExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -223,6 +235,7 @@ export const scopedExpected = `
 export const nestedUpper = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -234,7 +247,7 @@ export const nestedUpper = `
 
 <Component let:item1>
 	<Component let:item2>
-		<div melt={$builder({ arg1: item1, arg2: '' })} />
+		<div use:melt={$builder({ arg1: item1, arg2: '' })} />
 	</Component>
 </Component>
 `;
@@ -242,6 +255,7 @@ export const nestedUpper = `
 export const nestedUpperExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -261,6 +275,7 @@ export const nestedUpperExpected = `
 export const nestedLower = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -272,7 +287,7 @@ export const nestedLower = `
 
 <Component let:item1>
 	<Component let:item2>
-		<div melt={$builder({ arg1: item2, arg2: '' })} />
+		<div use:melt={$builder({ arg1: item2, arg2: '' })} />
 	</Component>
 </Component>
 `;
@@ -280,6 +295,7 @@ export const nestedLower = `
 export const nestedLowerExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -299,6 +315,7 @@ export const nestedLowerExpected = `
 export const nestedBoth = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -310,7 +327,7 @@ export const nestedBoth = `
 
 <Component let:item1>
 	<Component let:item2>
-		<div melt={$builder({ arg1: item1, arg2: item2 })} />
+		<div use:melt={$builder({ arg1: item1, arg2: item2 })} />
 	</Component>
 </Component>
 `;
@@ -318,6 +335,7 @@ export const nestedBoth = `
 export const nestedBothExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -337,6 +355,7 @@ export const nestedBothExpected = `
 export const slotTemplate = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -348,7 +367,7 @@ export const slotTemplate = `
 
 <Component let:item1>
 	<svelte:fragment slot="name" let:item2>
-		<div melt={$builder({ arg1: item1, arg2: item2 })} />
+		<div use:melt={$builder({ arg1: item1, arg2: item2 })} />
 	</svelte:fragment>
 </Component>
 `;
@@ -356,6 +375,7 @@ export const slotTemplate = `
 export const slotTemplateExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {

--- a/tests/each_block/index.svelte.ts
+++ b/tests/each_block/index.svelte.ts
@@ -1,6 +1,7 @@
 export const basicEach = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -11,13 +12,14 @@ export const basicEach = `
 </script>
 
 {#each [1, 2, 3] as item}
-	<div melt={$builder({ arg1: item, arg2: '' })} />
+	<div use:melt={$builder({ arg1: item, arg2: '' })} />
 {/each}
 `;
 
 export const basicEachExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -35,6 +37,7 @@ export const basicEachExpected = `
 export const controlEach = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -45,13 +48,14 @@ export const controlEach = `
 </script>
 
 {#each [1, 2, 3] as item}
-	<div melt={$builder({ arg1: 1, arg2: '' })} />
+	<div use:melt={$builder({ arg1: 1, arg2: '' })} />
 {/each}
 `;
 
 export const controlEachExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -71,6 +75,7 @@ $: __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' });
 export const basicIdentifierEach = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable({
 		role: 'Mock',
@@ -79,13 +84,14 @@ export const basicIdentifierEach = `
 </script>
 
 {#each [1, 2, 3] as item}
-	<div melt={$builder} />
+	<div use:melt={$builder} />
 {/each}
 `;
 
 export const basicIdentifierEachExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable({
 		role: 'Mock',
@@ -101,6 +107,7 @@ export const basicIdentifierEachExpected = `
 export const duplicateEach = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -111,13 +118,14 @@ export const duplicateEach = `
 </script>
 
 {#each [1, 2, 3] as item}
-	<div melt={$builder({ arg1: item, arg2: item })} />
+	<div use:melt={$builder({ arg1: item, arg2: item })} />
 {/each}
 `;
 
 export const duplicateEachExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -135,6 +143,7 @@ export const duplicateEachExpected = `
 export const destructuredEach = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -145,13 +154,14 @@ export const destructuredEach = `
 </script>
 
 {#each [{item1: 1, item2: 1}, {item1: 2, item2: 2}, {item1: 3, item2: 3}] as {item1, item2}}
-	<div melt={$builder({ arg1: item1, arg2: item2 })} />
+	<div use:melt={$builder({ arg1: item1, arg2: item2 })} />
 {/each}
 `;
 
 export const destructuredEachExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -169,6 +179,7 @@ export const destructuredEachExpected = `
 export const scopedEach = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -180,7 +191,7 @@ export const scopedEach = `
 
 {#each [1, 2, 3] as item}
 	{#each [4, 5, 6] as item}
-		<div melt={$builder({ arg1: item, arg2: '' })} />
+		<div use:melt={$builder({ arg1: item, arg2: '' })} />
 	{/each}
 {/each}
 `;
@@ -188,6 +199,7 @@ export const scopedEach = `
 export const scopedEachExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -207,6 +219,7 @@ export const scopedEachExpected = `
 export const nestedEachUpper = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -218,7 +231,7 @@ export const nestedEachUpper = `
 
 {#each [1, 2, 3] as item}
 	{#each [4, 5, 6] as item2}
-		<div melt={$builder({ arg1: item, arg2: '' })} />
+		<div use:melt={$builder({ arg1: item, arg2: '' })} />
 	{/each}
 {/each}
 `;
@@ -226,6 +239,7 @@ export const nestedEachUpper = `
 export const nestedEachUpperExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -245,6 +259,7 @@ export const nestedEachUpperExpected = `
 export const nestedEachLower = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -256,7 +271,7 @@ export const nestedEachLower = `
 
 {#each [1, 2, 3] as item}
 	{#each [4, 5, 6] as item2}
-		<div melt={$builder({ arg1: item2, arg2: '' })} />
+		<div use:melt={$builder({ arg1: item2, arg2: '' })} />
 	{/each}
 {/each}
 `;
@@ -264,6 +279,7 @@ export const nestedEachLower = `
 export const nestedEachLowerExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -283,6 +299,7 @@ export const nestedEachLowerExpected = `
 export const nestedEachBoth = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -294,7 +311,7 @@ export const nestedEachBoth = `
 
 {#each [1, 2, 3] as item}
 	{#each [4, 5, 6] as item2}
-		<div melt={$builder({ arg1: item, arg2: item2 })} />
+		<div use:melt={$builder({ arg1: item, arg2: item2 })} />
 	{/each}
 {/each}
 `;
@@ -302,6 +319,7 @@ export const nestedEachBoth = `
 export const nestedEachBothExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {

--- a/tests/expression_builder/index.svelte.ts
+++ b/tests/expression_builder/index.svelte.ts
@@ -1,6 +1,7 @@
 export const callExpression = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -10,12 +11,13 @@ export const callExpression = `
 	});
 </script>
 
-<div melt={$builder({ arg1: 1, arg2: '' })} />
+<div use:melt={$builder({ arg1: 1, arg2: '' })} />
 `;
 
 export const callExpressionExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -33,6 +35,7 @@ $: __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' });
 export const objExpression = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -42,12 +45,13 @@ export const objExpression = `
 	});
 </script>
 
-<div melt={{ ...$builder({ arg1: 1, arg2: '' }) }} />
+<div use:melt={{ ...$builder({ arg1: 1, arg2: '' }) }} />
 `;
 
 export const objExpressionExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -65,6 +69,7 @@ $: __MELTUI_BUILDER_0__ = { ...$builder({ arg1: 1, arg2: '' }) };
 export const multiExpressions = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {
@@ -74,14 +79,15 @@ export const multiExpressions = `
 	});
 </script>
 
-<div melt={$builder({ arg1: 1, arg2: '' })} />
-<div melt={$builder({ arg1: 1, arg2: '' })} />
-<div melt={$builder({ arg1: 1, arg2: '' })} />
+<div use:melt={$builder({ arg1: 1, arg2: '' })} />
+<div use:melt={$builder({ arg1: 1, arg2: '' })} />
+<div use:melt={$builder({ arg1: 1, arg2: '' })} />
 `;
 
 export const multiExpressionsExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable(({ arg1, arg2 }) => {
 		return {

--- a/tests/simple_builder/index.svelte.ts
+++ b/tests/simple_builder/index.svelte.ts
@@ -1,6 +1,7 @@
 export const simple = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable({
 		role: 'Mock',
@@ -8,12 +9,13 @@ export const simple = `
 	});
 </script>
 
-<div melt={$builder} />
+<div use:melt={$builder} />
 `;
 
 export const simpleExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable({
 		role: 'Mock',
@@ -27,6 +29,7 @@ export const simpleExpected = `
 export const aliased = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable({
 		role: 'Mock',
@@ -44,13 +47,14 @@ export const aliased = `
 	const expressionAlias = $expressionBuilder({ arg1: 1, arg2: '' });
 </script>
 
-<div melt={alias} />
-<div melt={expressionAlias} />
+<div use:melt={alias} />
+<div use:melt={expressionAlias} />
 `;
 
 export const aliasedExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 
 	const builder = writable({
 		role: 'Mock',
@@ -75,6 +79,7 @@ export const aliasedExpected = `
 export const ignoreComps = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 	import Comp from "./Comp.svelte";
 
 	const builder = writable({
@@ -83,19 +88,20 @@ export const ignoreComps = `
 	});
 </script>
 
-<div melt={$builder} />
+<div use:melt={$builder} />
 
-<Comp melt={$builder} />
-<Comp melt={builder} />
+<Comp use:melt={$builder} />
+<Comp use:melt={builder} />
 
-<Comp melt={$builder}>
-	<div melt={$builder} />
+<Comp use:melt={$builder}>
+	<div use:melt={$builder} />
 </Comp>
 `;
 
 export const ignoreCompsExpected = `
 <script>
 	import { writable } from 'svelte/store';
+	import { melt } from '@melt-ui/svelte';
 	import Comp from "./Comp.svelte";
 
 	const builder = writable({
@@ -106,54 +112,10 @@ export const ignoreCompsExpected = `
 
 <div {...$builder} use:$builder.action />
 
-<Comp melt={$builder} />
-<Comp melt={builder} />
+<Comp use:melt={$builder} />
+<Comp use:melt={builder} />
 
-<Comp melt={$builder}>
+<Comp use:melt={$builder}>
 	<div {...$builder} use:$builder.action />
-</Comp>
-`;
-
-export const meltAlias = `
-<script>
-	import { writable } from 'svelte/store';
-	import Comp from "./Comp.svelte";
-
-	const builder = writable({
-		role: 'Mock',
-		action: () => {},
-	});
-
-	$: melt = $builder;
-</script>
-
-<div {melt} />
-
-<Comp {melt} />
-
-<Comp {melt}>
-	<div {melt} />
-</Comp>
-`;
-
-export const meltAliasExpected = `
-<script>
-	import { writable } from 'svelte/store';
-	import Comp from "./Comp.svelte";
-
-	const builder = writable({
-		role: 'Mock',
-		action: () => {},
-	});
-
-	$: melt = $builder;
-</script>
-
-<div {...melt} use:melt.action />
-
-<Comp {melt} />
-
-<Comp {melt}>
-	<div {...melt} use:melt.action />
 </Comp>
 `;

--- a/tests/simple_builder/index.test.ts
+++ b/tests/simple_builder/index.test.ts
@@ -5,8 +5,6 @@ import {
 	simpleExpected,
 	aliased,
 	aliasedExpected,
-	meltAlias,
-	meltAliasExpected,
 	ignoreComps,
 	ignoreCompsExpected,
 } from './index.svelte';
@@ -29,14 +27,6 @@ describe('Simple Builder - Identifiers', () => {
 		});
 
 		expect(processed?.code).toBe(aliasedExpected);
-	});
-
-	it('builder aliased as melt with AttributeShorthand', async () => {
-		const processed = await markup({
-			content: meltAlias,
-		});
-
-		expect(processed?.code).toBe(meltAliasExpected);
 	});
 
 	it('ignore component props', async () => {


### PR DESCRIPTION
## TODO BEFORE MERGING
- [ ] Update the peer dependency version for `@melt-ui/svelte` to the version that uses the `melt` action once [*The Big Bad*](https://github.com/melt-ui/melt-ui/pull/234) is ready 