### PR TITLE
chore: Simplified `{@const}` tag injection logic and prettified the output

### DIFF
--- a/.changeset/smooth-needles-cry.md
+++ b/.changeset/smooth-needles-cry.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/pp': patch
+---
+
+chore: Simplified internal logic for injecting `{@const}` tags

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -44,27 +44,3 @@ export function walk<AST extends TemplateNode | Array<Node>, Node extends Templa
 	// @ts-expect-error do this once so i don't have to keep adding these ignores
 	return svelte_walk(ast, args);
 }
-
-/**
- * Extracts all the identifiers found in the expression.
- */
-export function extractIdentifiers<Expression extends TemplateNode>(
-	expression: Expression
-) {
-	const identifiers = new Set<string>();
-	// get all the identifiers found in the expression
-	walk(expression, {
-		enter(node, parent) {
-			if (node.type === 'Identifier') {
-				// ignore property keys
-				if (parent?.type === 'Property' && parent.key === node) {
-					this.skip();
-					return;
-				}
-				identifiers.add(node.name);
-			}
-		},
-	});
-
-	return identifiers;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export function preprocessMeltUI(options?: PreprocessOptions): PreprocessorGroup
 				} else {
 					// otherwise, we'll take the expression and hoist it into the script node
 					identifier = getMeltBuilderName(config.builderCount++);
-					identifiersToInsert += `$: ${identifier} = ${builder.expression.contents};\n`;
+					identifiersToInsert += `\t$: ${identifier} = ${builder.expression.contents};\n`;
 				}
 
 				const attributes = `{...${identifier}} use:${identifier}.action`;

--- a/src/traverse/AwaitBlock.ts
+++ b/src/traverse/AwaitBlock.ts
@@ -1,8 +1,7 @@
-import { extractIdentifiers } from '../helpers.js';
 import { traverseBlock } from './Block.js';
 
 import type { TemplateNode } from 'svelte/types/compiler/interfaces';
-import type { Config, LeftoverAction } from '../types.js';
+import type { Config } from '../types.js';
 
 type TraverseAwaitBlockArgs = {
 	awaitBlockNode: TemplateNode;
@@ -10,20 +9,6 @@ type TraverseAwaitBlockArgs = {
 };
 export function traverseAwaitBlock({ awaitBlockNode, config }: TraverseAwaitBlockArgs) {
 	if (awaitBlockNode.type !== 'AwaitBlock') throw Error('This node is not an AwaitBlock');
-
-	const awaitBlockIdentifiers = new Set<string>();
-	const value = awaitBlockNode.value; // {:then VALUE} or {#await promise then VALUE}
-	const error = awaitBlockNode.error; // {:catch ERROR}
-	const leftOverActions: LeftoverAction[] = [];
-
-	// get all the identifiers found in the await block value
-	extractIdentifiers(value).forEach((identifier) =>
-		awaitBlockIdentifiers.add(identifier)
-	);
-	// get all the identifiers found in the await block error
-	extractIdentifiers(error).forEach((identifier) =>
-		awaitBlockIdentifiers.add(identifier)
-	);
 
 	/* determine if those identifiers are being used in the melt action's expression */
 
@@ -38,6 +23,4 @@ export function traverseAwaitBlock({ awaitBlockNode, config }: TraverseAwaitBloc
 		blockNode: awaitBlockNode.catch,
 		config,
 	});
-
-	return leftOverActions;
 }

--- a/src/traverse/AwaitBlock.ts
+++ b/src/traverse/AwaitBlock.ts
@@ -25,18 +25,17 @@ export function traverseAwaitBlock({ awaitBlockNode, config }: TraverseAwaitBloc
 		awaitBlockIdentifiers.add(identifier)
 	);
 
-	// determine if those identifiers are being used in the melt action's expression
+	/* determine if those identifiers are being used in the melt action's expression */
+
+	// then block
 	traverseBlock({
-		blockIdentifiers: awaitBlockIdentifiers,
 		blockNode: awaitBlockNode.then,
-		leftOverActions,
 		config,
 	});
 
+	// catch block
 	traverseBlock({
-		blockIdentifiers: awaitBlockIdentifiers,
 		blockNode: awaitBlockNode.catch,
-		leftOverActions,
 		config,
 	});
 

--- a/src/traverse/ComponentBlock.ts
+++ b/src/traverse/ComponentBlock.ts
@@ -34,9 +34,7 @@ export function traverseComponentBlock({ compBlockNode, config }: TraverseEachBl
 
 	// determine if those identifiers are scoped to this block
 	traverseBlock({
-		blockIdentifiers: compBlockIdentifiers,
 		blockNode: compBlockNode,
-		leftOverActions,
 		config,
 	});
 

--- a/src/traverse/ComponentBlock.ts
+++ b/src/traverse/ComponentBlock.ts
@@ -1,8 +1,7 @@
-import { extractIdentifiers, walk } from '../helpers.js';
 import { traverseBlock } from './Block.js';
 
 import type { TemplateNode } from 'svelte/types/compiler/interfaces';
-import type { Config, LeftoverAction } from '../types.js';
+import type { Config } from '../types.js';
 
 type TraverseEachBlockArgs = {
 	compBlockNode: TemplateNode;
@@ -12,31 +11,9 @@ export function traverseComponentBlock({ compBlockNode, config }: TraverseEachBl
 	if (compBlockNode.type !== 'InlineComponent' && compBlockNode.type !== 'SlotTemplate')
 		throw Error('This node is not an InlineComponent or a SlotTemplate');
 
-	const compBlockIdentifiers = new Set<string>();
-	const leftOverActions: LeftoverAction[] = [];
-
-	// extracts all the identifiers from the `let:data` attributes
-	walk(compBlockNode.attributes, {
-		enter(letNode) {
-			if (letNode.type !== 'Let') return;
-
-			if (letNode.expression === null) {
-				// if it's just `let:data`, then `data` is the identifier
-				compBlockIdentifiers.add(letNode.name);
-			} else {
-				// otherwise, get all the identifiers found in the expression `let:data={expression}`
-				extractIdentifiers(letNode.expression).forEach((identifier) =>
-					compBlockIdentifiers.add(identifier)
-				);
-			}
-		},
-	});
-
 	// determine if those identifiers are scoped to this block
 	traverseBlock({
 		blockNode: compBlockNode,
 		config,
 	});
-
-	return leftOverActions;
 }

--- a/src/traverse/EachBlock.ts
+++ b/src/traverse/EachBlock.ts
@@ -22,9 +22,7 @@ export function traverseEachBlock({ eachBlockNode, config }: TraverseEachBlockAr
 
 	// determine if those identifiers are being used in the melt action's expression
 	traverseBlock({
-		blockIdentifiers: eachBlockIdentifiers,
 		blockNode: eachBlockNode,
-		leftOverActions,
 		config,
 	});
 

--- a/src/traverse/EachBlock.ts
+++ b/src/traverse/EachBlock.ts
@@ -1,8 +1,7 @@
-import { extractIdentifiers } from '../helpers.js';
 import { traverseBlock } from './Block.js';
 
 import type { TemplateNode } from 'svelte/types/compiler/interfaces';
-import type { Config, LeftoverAction } from '../types.js';
+import type { Config } from '../types.js';
 
 type TraverseEachBlockArgs = {
 	eachBlockNode: TemplateNode;
@@ -11,20 +10,9 @@ type TraverseEachBlockArgs = {
 export function traverseEachBlock({ eachBlockNode, config }: TraverseEachBlockArgs) {
 	if (eachBlockNode.type !== 'EachBlock') throw Error('This node is not an EachBlock');
 
-	const eachBlockIdentifiers = new Set<string>();
-	const context = eachBlockNode.context; // {#each someIterable as CONTEXT}
-	const leftOverActions: LeftoverAction[] = [];
-
-	// get all the identifiers found in the of the each block declaration
-	extractIdentifiers(context).forEach((identifier) =>
-		eachBlockIdentifiers.add(identifier)
-	);
-
 	// determine if those identifiers are being used in the melt action's expression
 	traverseBlock({
 		blockNode: eachBlockNode,
 		config,
 	});
-
-	return leftOverActions;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 import type { Node as ESTreeNode } from 'estree';
 import type MagicString from 'magic-string';
-import { TemplateNode } from 'svelte/types/compiler/interfaces';
 
 export type Builder = BuilderIdentifier | BuilderExpression;
 
@@ -33,5 +32,3 @@ export type Config = {
 	content: string;
 	builderCount: number;
 };
-
-export type LeftoverAction = { actionNode: TemplateNode; directBlockNode: TemplateNode };

--- a/tests/await_block/index.svelte.ts
+++ b/tests/await_block/index.svelte.ts
@@ -35,9 +35,11 @@ export const basicAwaitExpected = `
 
 {#await promise}
 	<div />
-{:then item}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
+{:then item}
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
 	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
-{:catch error}{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error, arg2: '' })}
+{:catch error}
+	{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error, arg2: '' })}
 	<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 {/await}
 `;
@@ -75,9 +77,11 @@ export const basicShorthandAwaitExpected = `
 	});
 </script>
 
-{#await promise then item}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
+{#await promise then item}
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
 	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
-{:catch error}{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error, arg2: '' })}
+{:catch error}
+	{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error, arg2: '' })}
 	<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 {/await}
 `;
@@ -119,9 +123,11 @@ export const controlAwaitExpected = `
 
 {#await promise}
 	<div />
-{:then item}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' })}
+{:then item}
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' })}
 	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
-{:catch error}{@const __MELTUI_BUILDER_1__ = $builder({ arg1: 1, arg2: '' })}
+{:catch error}
+	{@const __MELTUI_BUILDER_1__ = $builder({ arg1: 1, arg2: '' })}
 	<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 {/await}
 `;
@@ -203,9 +209,11 @@ export const duplicateIdentifierAwaitExpected = `
 
 {#await promise}
 	<div />
-{:then item}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item })}
+{:then item}
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item })}
 	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
-{:catch error}{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error, arg2: error })}
+{:catch error}
+	{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error, arg2: error })}
 	<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 {/await}
 `;
@@ -247,9 +255,11 @@ export const destructuredAwaitExpected = `
 
 {#await promise}
 	<div />
-{:then {item1, item2}}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
+{:then {item1, item2}}
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
 	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
-{:catch {error1, error2}}{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error1, arg2: error2 })}
+{:catch {error1, error2}}
+	{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error1, arg2: error2 })}
 	<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 {/await}
 `;
@@ -297,18 +307,24 @@ export const scopedAwaitExpected = `
 	});
 </script>
 
-{#await promise then item}{@const __MELTUI_BUILDER_2__ = $builder({ arg1: item, arg2: '' })}
+{#await promise then item}
+	{@const __MELTUI_BUILDER_2__ = $builder({ arg1: item, arg2: '' })}
 	<div {...__MELTUI_BUILDER_2__} use:__MELTUI_BUILDER_2__.action />
-	{#await promise then item}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
+	{#await promise then item}
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
 		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
-	{:catch error}{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error, arg2: '' })}
+	{:catch error}
+		{@const __MELTUI_BUILDER_1__ = $builder({ arg1: error, arg2: '' })}
 		<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 	{/await}
-{:catch error}{@const __MELTUI_BUILDER_5__ = $builder({ arg1: error, arg2: '' })}
+{:catch error}
+	{@const __MELTUI_BUILDER_5__ = $builder({ arg1: error, arg2: '' })}
 	<div {...__MELTUI_BUILDER_5__} use:__MELTUI_BUILDER_5__.action />
-	{#await promise2 then item}{@const __MELTUI_BUILDER_3__ = $builder({ arg1: item, arg2: '' })}
+	{#await promise2 then item}
+		{@const __MELTUI_BUILDER_3__ = $builder({ arg1: item, arg2: '' })}
 		<div {...__MELTUI_BUILDER_3__} use:__MELTUI_BUILDER_3__.action />
-	{:catch error}{@const __MELTUI_BUILDER_4__ = $builder({ arg1: error, arg2: '' })}
+	{:catch error}
+		{@const __MELTUI_BUILDER_4__ = $builder({ arg1: error, arg2: '' })}
 		<div {...__MELTUI_BUILDER_4__} use:__MELTUI_BUILDER_4__.action />
 	{/await}
 {/await}
@@ -356,15 +372,19 @@ export const nestedAwaitUpperExpected = `
 </script>
 
 {#await promise then item}
-	{#await promise then item2}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
+	{#await promise then item2}
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
 		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
-	{:catch error}{@const __MELTUI_BUILDER_1__ = $builder({ arg1: item, arg2: '' })}
+	{:catch error}
+		{@const __MELTUI_BUILDER_1__ = $builder({ arg1: item, arg2: '' })}
 		<div {...__MELTUI_BUILDER_1__} use:__MELTUI_BUILDER_1__.action />
 	{/await}
 {:catch error1}
-	{#await promise then item}{@const __MELTUI_BUILDER_2__ = $builder({ arg1: error1, arg2: '' })}
+	{#await promise then item}
+		{@const __MELTUI_BUILDER_2__ = $builder({ arg1: error1, arg2: '' })}
 		<div {...__MELTUI_BUILDER_2__} use:__MELTUI_BUILDER_2__.action />
-	{:catch error2}{@const __MELTUI_BUILDER_3__ = $builder({ arg1: error1, arg2: '' })}
+	{:catch error2}
+		{@const __MELTUI_BUILDER_3__ = $builder({ arg1: error1, arg2: '' })}
 		<div {...__MELTUI_BUILDER_3__} use:__MELTUI_BUILDER_3__.action />
 	{/await}
 {/await}
@@ -404,7 +424,8 @@ export const nestedAwaitLowerExpected = `
 </script>
 
 {#await promise then item}
-	{#await promise then item2}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item2, arg2: '' })}
+	{#await promise then item2}
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item2, arg2: '' })}
 		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{/await}
 {/await}
@@ -444,7 +465,8 @@ export const nestedAwaitBothExpected = `
 </script>
 
 {#await promise then item}
-	{#await promise then item2}{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
+	{#await promise then item2}
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
 		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{/await}
 {/await}

--- a/tests/component_block/index.svelte.ts
+++ b/tests/component_block/index.svelte.ts
@@ -29,7 +29,8 @@ export const basicComponentExpected = `
 	});
 </script>
 
-<Component let:data={item}>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
+<Component let:data={item}>
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
 	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 </Component>
 `;
@@ -65,7 +66,8 @@ export const basicShorthandExpected = `
 	});
 </script>
 
-<Component let:item>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
+<Component let:item>
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
 	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 </Component>
 `;
@@ -101,7 +103,8 @@ export const controlExpected = `
 	});
 </script>
 
-<Component let:item>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' })}
+<Component let:item>
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' })}
 	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 </Component>
 `;
@@ -149,7 +152,8 @@ export const duplicateIdentifierExpected = `
 	});
 </script>
 
-<Component let:item>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item })}
+<Component let:item>
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item })}
 	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 </Component>
 `;
@@ -185,7 +189,8 @@ export const destructuredExpected = `
 	});
 </script>
 
-<Component let:item={{item1, item2}}>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
+<Component let:item={{item1, item2}}>
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
 	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 </Component>
 `;
@@ -224,7 +229,8 @@ export const scopedExpected = `
 </script>
 
 <Component let:item>
-	<Component let:item>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
+	<Component let:item>
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
 		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	</Component>
 </Component>
@@ -264,7 +270,8 @@ export const nestedUpperExpected = `
 </script>
 
 <Component let:item1>
-	<Component let:item2>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: '' })}
+	<Component let:item2>
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: '' })}
 		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	</Component>
 </Component>
@@ -304,7 +311,8 @@ export const nestedLowerExpected = `
 </script>
 
 <Component let:item1>
-	<Component let:item2>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item2, arg2: '' })}
+	<Component let:item2>
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item2, arg2: '' })}
 		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	</Component>
 </Component>
@@ -344,7 +352,8 @@ export const nestedBothExpected = `
 </script>
 
 <Component let:item1>
-	<Component let:item2>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
+	<Component let:item2>
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
 		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	</Component>
 </Component>
@@ -384,7 +393,8 @@ export const slotTemplateExpected = `
 </script>
 
 <Component let:item1>
-	<svelte:fragment slot="name" let:item2>{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
+	<svelte:fragment slot="name" let:item2>
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
 		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	</svelte:fragment>
 </Component>

--- a/tests/each_block/index.svelte.ts
+++ b/tests/each_block/index.svelte.ts
@@ -30,7 +30,8 @@ export const basicEachExpected = `
 </script>
 
 {#each [1, 2, 3] as item}
-	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 {/each}
 `;
 
@@ -66,7 +67,8 @@ export const controlEachExpected = `
 </script>
 
 {#each [1, 2, 3] as item}
-	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' })}
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 {/each}
 `;
 
@@ -134,7 +136,8 @@ export const duplicateEachExpected = `
 </script>
 
 {#each [1, 2, 3] as item}
-	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item })}
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 {/each}
 `;
 
@@ -170,7 +173,8 @@ export const destructuredEachExpected = `
 </script>
 
 {#each [{item1: 1, item2: 1}, {item1: 2, item2: 2}, {item1: 3, item2: 3}] as {item1, item2}}
-	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
+	{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item1, arg2: item2 })}
+	<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 {/each}
 `;
 
@@ -209,7 +213,8 @@ export const scopedEachExpected = `
 
 {#each [1, 2, 3] as item}
 	{#each [4, 5, 6] as item}
-		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{/each}
 {/each}
 `;
@@ -249,7 +254,8 @@ export const nestedEachUpperExpected = `
 
 {#each [1, 2, 3] as item}
 	{#each [4, 5, 6] as item2}
-		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: '' })}
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{/each}
 {/each}
 `;
@@ -289,7 +295,8 @@ export const nestedEachLowerExpected = `
 
 {#each [1, 2, 3] as item}
 	{#each [4, 5, 6] as item2}
-		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item2, arg2: '' })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item2, arg2: '' })}
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{/each}
 {/each}
 `;
@@ -329,7 +336,8 @@ export const nestedEachBothExpected = `
 
 {#each [1, 2, 3] as item}
 	{#each [4, 5, 6] as item2}
-		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item2 })}<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
+		{@const __MELTUI_BUILDER_0__ = $builder({ arg1: item, arg2: item2 })}
+		<div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
 	{/each}
 {/each}
 `;
@@ -380,7 +388,8 @@ export const thumbEachExpected = `
 	</span>
 
 	{#each $value as _}
-		{@const __MELTUI_BUILDER_0__ = $thumb()}<span
+		{@const __MELTUI_BUILDER_0__ = $thumb()}
+		<span
 			{...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action
 			class="block h-5 w-5 rounded-full bg-white focus:ring-4 focus:ring-black/40"
 		/>

--- a/tests/expression_builder/index.svelte.ts
+++ b/tests/expression_builder/index.svelte.ts
@@ -26,7 +26,7 @@ export const callExpressionExpected = `
 		};
 	});
 
-$: __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' });
+	$: __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' });
 </script>
 
 <div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
@@ -60,7 +60,7 @@ export const objExpressionExpected = `
 		};
 	});
 
-$: __MELTUI_BUILDER_0__ = { ...$builder({ arg1: 1, arg2: '' }) };
+	$: __MELTUI_BUILDER_0__ = { ...$builder({ arg1: 1, arg2: '' }) };
 </script>
 
 <div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />
@@ -96,9 +96,9 @@ export const multiExpressionsExpected = `
 		};
 	});
 
-$: __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' });
-$: __MELTUI_BUILDER_1__ = $builder({ arg1: 1, arg2: '' });
-$: __MELTUI_BUILDER_2__ = $builder({ arg1: 1, arg2: '' });
+	$: __MELTUI_BUILDER_0__ = $builder({ arg1: 1, arg2: '' });
+	$: __MELTUI_BUILDER_1__ = $builder({ arg1: 1, arg2: '' });
+	$: __MELTUI_BUILDER_2__ = $builder({ arg1: 1, arg2: '' });
 </script>
 
 <div {...__MELTUI_BUILDER_0__} use:__MELTUI_BUILDER_0__.action />


### PR DESCRIPTION
As of `0.1.0`, the method of determining where an `{@const}` tag would be injected has changed. This new heuristic is _much_ simpler than the previous iteration. As such, I've ripped out much of the logic that used to be needed.

I've also prettified the output so that it's more readable.