### PR TITLE
chore: Remove engine restrictions

### DIFF
--- a/.changeset/stale-chairs-yawn.md
+++ b/.changeset/stale-chairs-yawn.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/pp': patch
+---
+
+chore: Removed required engine restrictions

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@melt-ui/pp",
 	"version": "0.3.0",
-	"description": "",
+	"description": "Preprocessor for Melt UI",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"type": "module",
@@ -44,10 +44,6 @@
 	"peerDependencies": {
 		"@melt-ui/svelte": ">= 0.29.0",
 		"svelte": "^3.55.0 || ^4.0.0 || ^5.0.0-next.1"
-	},
-	"packageManager": "pnpm@8.6.3",
-	"engines": {
-		"pnpm": ">=8.6.3"
 	},
 	"dependencies": {
 		"estree-walker": "^3.0.3",


### PR DESCRIPTION
Should've done this a while ago, especially since the release pnpm v9 where this field is now considered in dependencies.

closes #54